### PR TITLE
Fixed #754: inappropriate format and inappropriate text color

### DIFF
--- a/02-fundamentals.Rmd
+++ b/02-fundamentals.Rmd
@@ -51,12 +51,10 @@ $${Data \ Ink \ Ratio} = \frac{{Data \ Ink}}{{Total \ Ink}}$$
 
 This basic idea is illustrated in the following visualizations.
 
-**Erase non-data-ink and redundant data-ink.**
-![](images/Tufte_figure1.png){width=250px,height=200px}
+![Erase non-data-ink and redundant data-ink.](images/Tufte_figure1.png){width=250px,height=200px}
 (Source:[@Tufte_2001])
 
-**Erase non-data-ink and redundant data-ink.**
-![](images/Tufte_figure2.png){width=250px,height=200px}
+![Erase non-data-ink and redundant data-ink.](images/Tufte_figure2.png){width=250px,height=200px}
 (Source: [@appli_2017])
 
 ![](images/Tufte_figure3.png){width=250px,height=200px}


### PR DESCRIPTION
Last week, I mentioned the figures of 3.1.3.1 text description("Erase non-data-ink and redundant data-ink"(line 54) and " Erase non-data-ink and redundant data-ink"(line 59)) have impropriate format and impropriate text color.
This week,I insert 'Erase non-data-ink and redundant data-ink' in each figure's alternative text to match other text description font format and color in the article.