### PR TITLE
Fixed issue#785 - Section 6.6 content does not belong to Data Ethics

### DIFF
--- a/03-casestudies.Rmd
+++ b/03-casestudies.Rmd
@@ -185,6 +185,17 @@ Google’s Music Timeline illustrates a variety of music genres waxing and wanin
 
 (Source:[@google_music])
 
+## Visualizing Urban Data for Social Change
+[@Socialchange]
+
+One field in which visualization can have a meaningful social impact is promoting understanding of and generating discussions around cities. With the development of a city, demographic changes, economic, environmental and social problems become important issues. Visualization plays an important role in promoting understanding of how the cities and the societies within them work, debating the problems that cities face, and engaging citizens to work toward their dream cities.
+
+Recently, as part of Habitat III side event , LlactaLAB - Sustainable Cities Research Group, presented a project called Live Infographics. It was an interactive methodology that put citizens and experts opinions about the New Urban Agenda on one platform to help generate a 'horizontal governance'. The different opinions were materialized with a dynamic map to visualize the generated data. The primary objective of the project is to generate citizen-led data collection and to enable governments to build a better understanding of public sentiment, and then engaging people in the process.
+
+A great Urban Data Visualization ought to have the capacity to start "Sociological Imagination". It should provoke individuals to consider how their individual choices, issues, struggles, and in general their daily lives, are a extension of society, and how their choices collectively influence public opinion.
+
+As urban areas continue to develop, diverse and complex issues evolve along with them. Disparity, isolation, loss of biodiversity and environmental quality, etc. are all important but thorny issues, and finding successful solutions will require uniting strategy producers, academics, designers, and citizens. Visualization, if done right, can help jumpstart important discussions between these diverse groups of people and help solve the issues that emerge as the world becomes more urbanized.
+
 ## Animated Data Visualization
 Like evolving demographics, these visualizations are demographics that change over time. These, however, are self-animated instead of interactive.
 

--- a/05-ethics.Rmd
+++ b/05-ethics.Rmd
@@ -94,18 +94,6 @@ The discussion on perspective is an interesting one; it asks how data visualizer
 
 Of course, the challenge posed by the tug-of-war between ethics and utility ( not to say that they are always contradictory in nature)  remains central in many sciences, including the data sciences, and it makes the discussion of finding a balance between the two all the more important.
 
-
-## Data Visualization: A Tool for Social Change in Cities 
-[@socialchange]
-
-One field in which visualization can have a meaningful social impact is promoting understanding of and generating discussions around cities. With the development of a city, demographic changes, economic, environmental and social problems become important issues. Visualization plays an important role in promoting understanding of how the cities and the societies within them work, debating the problems that cities face, and engaging citizens to work toward their dream cities.
-
-Recently, as part of Habitat III side event , LlactaLAB - Sustainable Cities Research Group, presented a project called Live Infographics. It was an interactive methodology that put citizens and experts opinions about the New Urban Agenda on one platform to help generate a 'horizontal governance'. The different opinions were materialized with a dynamic map to visualize the generated data. The primary objective of the project is to generate citizen-led data collection and to enable governments to build a better understanding of public sentiment, and then engaging people in the process.
-
-A great Urban Data Visualization ought to have the capacity to start "Sociological Imagination". It should provoke individuals to consider how their individual choices, issues, struggles, and in general their daily lives, are a extension of society, and how their choices collectively influence public opinion.
-
-As urban areas continue to develop, diverse and complex issues evolve along with them. Disparity, isolation, loss of biodiversity and environmental quality, etc. are all important but thorny issues, and finding successful solutions will require uniting strategy producers, academics, designers, and citizens. Visualization, if done right, can help jumpstart important discussions between these diverse groups of people and help solve the issues that emerge as the world becomes more urbanized.
-
 ## Ethical Theory and Practice from Journalism and Engineering  
 [@poli_social_science]
 


### PR DESCRIPTION
1. Removed the section 6.6 from Ethics chapter  and moved it under case studies as a new section "Visualizing Urban Data for Social Change"
2. Fixed the citation reference to refer to the correct reference from book.bib [@Socialchange]