### PR TITLE
#Fix issue 773

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -2127,3 +2127,17 @@ title = {Scatter Plot},
 url = {https://python-graph-gallery.com/scatter-plot/},
 note = {Accessed: 2019-04-21}
 }
+
+@Website{cyber,
+  author = {Edward R. Tufte},
+  year = {2001},
+  title = {The Visual Display of Quantitative Information},
+  url = {https://cyber.rms.moe/books/03%20-%20General%20Science/The%20Visual%20Display%20of%20Quantitative%20Information%20-%20Edward%20Tufte.pdf},
+  note = {Accessed: 2019-04-24}
+}
+
+@Website{fusioncharts,
+  title = {Principles of Data Visualization - What We See in a Visual},
+  url = {https://www.fusioncharts.com/resources/whitepapers/principles-of-data-visualization},
+  note = {Accessed: 2019-04-24}
+}


### PR DESCRIPTION
In issue 773, I mentioned 'Unformatted reference citation' problem. I fixed the citation issue 
The reference citation format in Chap3 is not unify. As the following two citations : first one is not found , the second one is unclear where the source come from, is a book? Journal or Website?