### PR TITLE
Issue 918: Information about Chernoff's faces

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -1207,6 +1207,7 @@ year = {2018}
  author = {Tufte, Edward R.},
  title = {The Visual Display of Quantitative Information},
  year = {1986},
+ url = {https://cyber.rms.moe/books/03%20-%20General%20Science/The%20Visual%20Display%20of%20Quantitative%20Information%20-%20Edward%20Tufte.pdf},
  isbn = {0-9613921-0-X},
  publisher = {Graphics Press},
  address = {Cheshire, CT, USA},


### PR DESCRIPTION
Update book.bib. The information about Chernoff's faces is elaborate. The link for Tufte's "The Visual Display for Quantitative Information" was missing. Added the link, so that the information can be studied in detail. The information is found on page 142 of the book.